### PR TITLE
プレイリストのカバー画像未選択時、強制的に初期画像で上書きしてしまう不具合の修正

### DIFF
--- a/SongPlayListEditer/Properties/AssemblyInfo.cs
+++ b/SongPlayListEditer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyVersion("1.1.1")]
+[assembly: AssemblyFileVersion("1.1.1")]

--- a/SongPlayListEditer/UI/Views/EditView.cs
+++ b/SongPlayListEditer/UI/Views/EditView.cs
@@ -104,6 +104,7 @@ namespace SongPlayListEditer.UI.Views
         {
             try {
                 base.DidActivate(firstActivation, type);
+                this.CoverPath = null;
                 this.Title = null;
                 this.Author = null;
                 this.Description = null;
@@ -155,12 +156,13 @@ namespace SongPlayListEditer.UI.Views
                 this.Coordinator.CurrentPlaylist.Filename = this.Coordinator.CurrentPlaylist.Title;
             }
             Logger.Info($"Cover Path : [{this.CoverPath}]");
+            Logger.Info($"Has Cover? : {this.Coordinator.CurrentPlaylist.HasCover}");
             if (!string.IsNullOrEmpty(this.CoverPath)) {
                 using (var stream = new FileStream(this.CoverPath, FileMode.Open, FileAccess.Read)) {
                     this.Coordinator.CurrentPlaylist.SetCover(stream);
                 }
             }
-            else {
+            else if(!this.Coordinator.CurrentPlaylist.HasCover) {
                 using (var stream = Base64Sprites.Base64ToStream(DefaultImage.DEFAULT_IMAGE)) {
                     this.Coordinator.CurrentPlaylist.SetCover(stream);
                 }

--- a/SongPlayListEditer/manifest.json
+++ b/SongPlayListEditer/manifest.json
@@ -3,7 +3,7 @@
   "id": "SongPlayListEditer",
   "name": "SongPlayListEditer",
   "author": "denpadokei",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "gameVersion": "1.9.0",
   "dependsOn": {


### PR DESCRIPTION
前回編集時のカバー画像情報が残ってしまう不具合の修正